### PR TITLE
systemd.service: Restart the service if browser fails abruptly

### DIFF
--- a/yoe-kiosk-browser-eglfs.service
+++ b/yoe-kiosk-browser-eglfs.service
@@ -10,6 +10,7 @@ Environment=QTWEBENGINE_DISABLE_SANDBOX=1
 
 EnvironmentFile=/etc/default/yoe-kiosk-browser
 ExecStart=/usr/bin/yoe-kiosk-browser
+Restart=on-failure
 
 [Install]
 WantedBy=multi-user.target

--- a/yoe-kiosk-browser-wayland.service
+++ b/yoe-kiosk-browser-wayland.service
@@ -11,6 +11,7 @@ Environment=XDG_RUNTIME_DIR=/run/user/1000/
 
 EnvironmentFile=/etc/default/yoe-kiosk-browser
 ExecStart=/usr/bin/yoe-kiosk-browser
+Restart=on-failure
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
This ensures that service is kept up automatically.