### PR TITLE
yoe-kiosk-browser-wayland.service: Change to wayland-0 for default di…

### DIFF
--- a/yoe-kiosk-browser-wayland.service
+++ b/yoe-kiosk-browser-wayland.service
@@ -6,7 +6,7 @@ After=weston.service
 [Service]
 User=weston
 Environment=LANG=en_US.UTF-8
-Environment=WAYLAND_DISPLAY=wayland-1
+Environment=WAYLAND_DISPLAY=wayland-0
 Environment=XDG_RUNTIME_DIR=/run/user/1000/
 
 EnvironmentFile=/etc/default/yoe-kiosk-browser


### PR DESCRIPTION
…splay

With latest yocto it has moved to using wayland-0 instead of wayland-1 as default display socket both on imx8 and rpi4